### PR TITLE
Fix typo in Gatt.py, so that ATT_OP_HANDLE_CNF is handled.

### DIFF
--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -305,7 +305,7 @@ class Gatt:
             response = self.handlePrepareWriteRequest(request)
         elif requestType == ATT_OP_EXEC_WRITE_REQ:
             response = self.handleExecuteWriteRequest(request)
-        elif requestType == ATT_OP_EXEC_WRITE_REQ:
+        elif requestType == ATT_OP_HANDLE_CNF:
             response = self.handleConfirmation(request)
         else:
             # case ATT_OP_READ_MULTI_REQ:


### PR DESCRIPTION
This avoids an error response on Handle Value Confirmation,
which is sent by the central after an Indication
(related to an "Indicate" characteristic).